### PR TITLE
新增自适应启动与依赖清理脚本

### DIFF
--- a/clean.bat
+++ b/clean.bat
@@ -1,0 +1,86 @@
+@echo off
+setlocal EnableExtensions
+chcp 65001 >nul
+cd /d "%~dp0."
+
+echo ========================================
+echo KouriChat cleanup
+echo ========================================
+echo.
+echo This will remove:
+echo   - The uv tool installation: kourichat
+echo   - Downloaded wheel files in packages\
+echo   - Local virtual environments: .venv\ and venv\
+echo.
+echo It will keep:
+echo   - kourichat.toml
+echo   - data\ and other user files
+echo.
+choice /c YN /n /d Y /t 5 /m "Continue cleanup? [Y/N] "
+if errorlevel 2 goto :cancel
+
+set "UV_CMD=uv"
+where uv >nul 2>nul
+if errorlevel 1 if exist "%USERPROFILE%\.local\bin\uv.exe" set "UV_CMD=%USERPROFILE%\.local\bin\uv.exe"
+if errorlevel 1 if exist "%USERPROFILE%\.cargo\bin\uv.exe" set "UV_CMD=%USERPROFILE%\.cargo\bin\uv.exe"
+
+"%UV_CMD%" --version >nul 2>nul
+if errorlevel 1 goto :skip_uv
+
+"%UV_CMD%" tool list 2>nul | findstr /i /c:"kourichat" >nul
+if errorlevel 1 goto :uninstall_uv_tool
+
+echo [INFO] Uninstalling uv tool: kourichat...
+"%UV_CMD%" tool uninstall kourichat
+if errorlevel 1 echo [WARN] uv could not uninstall kourichat.
+
+goto :remove_files
+
+:uninstall_uv_tool
+echo [INFO] kourichat uv tool is not installed.
+
+:skip_uv
+echo [WARN] uv was not found. Skipping uv tool uninstall.
+
+goto :remove_files
+
+:remove_files
+if exist "packages" (
+    echo [INFO] Removing downloaded wheel cache: packages\
+    rmdir /s /q "packages"
+    if exist "packages" (echo [WARN] Could not remove packages\.) else (echo [OK] packages\ removed.)
+) else (
+    echo [INFO] No packages\ directory found.
+)
+
+if exist ".venv" (
+    echo [INFO] Removing local virtual environment: .venv\
+    rmdir /s /q ".venv"
+    if exist ".venv" (echo [WARN] Could not remove .venv\.) else (echo [OK] .venv\ removed.)
+)
+
+if exist "venv" (
+    echo [INFO] Removing local virtual environment: venv\
+    rmdir /s /q "venv"
+    if exist "venv" (echo [WARN] Could not remove venv\.) else (echo [OK] venv\ removed.)
+)
+
+echo.
+echo [OK] Dependency cleanup completed.
+echo [INFO] kourichat.toml and data\ were kept.
+goto :pause
+
+:cancel
+echo [INFO] Cleanup cancelled.
+
+goto :pause
+
+:pause
+echo.
+echo This window will close automatically in 5 seconds.
+for /l %%S in (5,-1,1) do (
+    <nul set /p "=Closing in %%S seconds...   "
+    powershell -NoProfile -Command "Start-Sleep -Seconds 1"
+    echo.
+)
+exit /b 0

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,216 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+cd /d "%~dp0."
+
+rem ============================================================================
+rem Editable download settings
+rem Change these URLs when the release version or mirror changes.
+rem GATEWAY_URL is intentionally empty because the official Release has no gateway.
+rem Put a direct community gateway URL here, then start.bat will download it.
+rem ============================================================================
+set "RELEASE_API_URL=https://api.github.com/repos/KouriChat/KouriChat/releases/latest"
+set "KOURI_WHL_NAME="
+set "ELIXIR_WHL_NAME="
+set "KOURI_WHL_URL="
+set "ELIXIR_WHL_URL="
+set "GATEWAY_FILE=openclaw-onebotv11.exe"
+set "GATEWAY_URL="
+
+rem Optional gateway example:
+rem set "GATEWAY_URL=https://example.com/path/openclaw-onebotv11.exe"
+
+set "MIRROR_1=https://gh-proxy.com/"
+set "MIRROR_2=https://ghproxy.net/"
+set "MIRROR_3=https://github.moeyy.xyz/"
+set "MIRROR_4=https://ghfast.top/"
+
+goto :bootstrap_uv
+
+:bootstrap_uv
+set "UV_CMD=uv"
+where uv >nul 2>nul
+if not errorlevel 1 goto :prepare_packages
+if exist "%USERPROFILE%\.local\bin\uv.exe" set "UV_CMD=%USERPROFILE%\.local\bin\uv.exe"
+if exist "%USERPROFILE%\.cargo\bin\uv.exe" set "UV_CMD=%USERPROFILE%\.cargo\bin\uv.exe"
+if exist "%~dp0uv.exe" set "UV_CMD=%~dp0uv.exe"
+"%UV_CMD%" --version >nul 2>nul
+if not errorlevel 1 goto :prepare_packages
+
+echo [INFO] uv not found. Installing uv...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
+if exist "%USERPROFILE%\.local\bin\uv.exe" set "UV_CMD=%USERPROFILE%\.local\bin\uv.exe"
+if exist "%USERPROFILE%\.cargo\bin\uv.exe" set "UV_CMD=%USERPROFILE%\.cargo\bin\uv.exe"
+"%UV_CMD%" --version >nul 2>nul
+if not errorlevel 1 goto :prepare_packages
+
+echo [ERROR] uv installation failed. Check your network or permissions.
+goto :fail
+
+:prepare_packages
+call :resolve_latest_release
+if errorlevel 1 goto :release_failed
+set "PKG_DIR=%~dp0packages"
+if not exist "%PKG_DIR%" mkdir "%PKG_DIR%"
+set "KOURI_WHL=%PKG_DIR%\%KOURI_WHL_NAME%"
+set "ELIXIR_WHL=%PKG_DIR%\%ELIXIR_WHL_NAME%"
+
+if exist "%KOURI_WHL%" goto :check_elixir
+
+echo [INFO] Downloading KouriChat package...
+call :download_wheel "%KOURI_WHL_NAME%" "%KOURI_WHL_URL%" "%KOURI_WHL%"
+if errorlevel 1 goto :download_failed
+
+:check_elixir
+if exist "%ELIXIR_WHL%" goto :install_package
+
+echo [INFO] Downloading Elixir core package...
+call :download_wheel "%ELIXIR_WHL_NAME%" "%ELIXIR_WHL_URL%" "%ELIXIR_WHL%"
+if errorlevel 1 goto :download_failed
+
+:install_package
+where kourichat >nul 2>nul
+if not errorlevel 1 goto :start_gateway
+
+echo [INFO] Installing KouriChat and Elixir with uv...
+"%UV_CMD%" tool install "%KOURI_WHL%" --with "%ELIXIR_WHL%" --force
+if errorlevel 1 goto :install_failed
+
+echo [INFO] Installation completed.
+
+:start_gateway
+if not exist "%GATEWAY_FILE%" if defined GATEWAY_URL call :download_gateway
+if not exist "%GATEWAY_FILE%" goto :gateway_missing
+tasklist /fi "imagename eq %GATEWAY_FILE%" 2>nul | find /i "%GATEWAY_FILE%" >nul
+if not errorlevel 1 goto :start_kourichat
+echo [INFO] Starting OpenClaw OneBot gateway...
+start "OpenClaw OneBot Gateway" "%GATEWAY_FILE%" run
+ping 127.0.0.1 -n 3 >nul
+goto :start_kourichat
+
+:gateway_missing
+echo.
+echo [ERROR] Required gateway file is missing: %GATEWAY_FILE%
+echo [INFO] Please put %GATEWAY_FILE% beside start.bat.
+echo [INFO] Or set GATEWAY_URL at the top of start.bat and run again.
+echo [INFO] KouriChat will not start until all required files are ready.
+goto :fail
+
+:start_kourichat
+where kourichat >nul 2>nul
+if errorlevel 1 goto :command_missing
+echo [INFO] Starting KouriChat...
+kourichat run
+goto :finish
+
+:command_missing
+echo [ERROR] kourichat command is unavailable after installation.
+echo Try opening a new terminal, then run: kourichat run
+goto :fail
+
+:release_failed
+echo [ERROR] Could not resolve the latest KouriChat Release.
+echo Please check GitHub API access or set fixed package URLs in the editable section.
+goto :fail
+
+:download_failed
+echo [ERROR] Required wheel download failed.
+echo Please check your network, mirror settings, or package URLs at the top of start.bat.
+echo KouriChat will not start until both wheel files are ready.
+goto :fail
+
+:install_failed
+echo [ERROR] uv failed to install KouriChat.
+echo Package files are cached in: %PKG_DIR%
+echo KouriChat will not start until installation succeeds.
+goto :fail
+
+:finish
+if not errorlevel 1 goto :success
+echo [ERROR] KouriChat exited with code %errorlevel%.
+goto :fail
+
+:success
+echo [INFO] KouriChat stopped normally.
+goto :pause
+
+:fail
+echo [INFO] Startup did not complete. Required files are still missing or invalid.
+echo Please complete the files above, then run start.bat again.
+echo.
+echo This window will close automatically in 5 seconds.
+for /l %%S in (5,-1,1) do (
+    <nul set /p "=Closing in %%S seconds...   "
+    powershell -NoProfile -Command "Start-Sleep -Seconds 1"
+    echo.
+)
+exit /b 1
+
+:resolve_latest_release
+set "RELEASE_INFO=%TEMP%\kourichat-latest-%RANDOM%.txt"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; try { $r=Invoke-RestMethod -UseBasicParsing -TimeoutSec 30 -Headers @{ 'User-Agent'='KouriChat-start' } -Uri '%RELEASE_API_URL%'; $k=$r.assets | Where-Object { $_.name -like 'kourichat-*.whl' } | Select-Object -First 1; $e=$r.assets | Where-Object { $_.name -like 'elixir-*.whl' } | Select-Object -First 1; if ($k -and $e) { @('KOURI_WHL_NAME=' + $k.name,'KOURI_WHL_URL=' + $k.browser_download_url,'ELIXIR_WHL_NAME=' + $e.name,'ELIXIR_WHL_URL=' + $e.browser_download_url) | Set-Content -Encoding ASCII '%RELEASE_INFO%'; exit 0 }; exit 1 } catch { exit 1 }"
+if errorlevel 1 exit /b 1
+if not exist "%RELEASE_INFO%" exit /b 1
+for /f "usebackq tokens=1,* delims==" %%A in ("%RELEASE_INFO%") do set "%%A=%%B"
+del /q "%RELEASE_INFO%" >nul 2>nul
+if not defined KOURI_WHL_NAME exit /b 1
+if not defined ELIXIR_WHL_NAME exit /b 1
+if not defined KOURI_WHL_URL exit /b 1
+if not defined ELIXIR_WHL_URL exit /b 1
+echo [INFO] Latest KouriChat package: %KOURI_WHL_NAME%
+echo [INFO] Latest Elixir package: %ELIXIR_WHL_NAME%
+exit /b 0
+
+:download_gateway
+if not defined GATEWAY_URL exit /b 1
+echo [INFO] Downloading gateway...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 -Uri '%GATEWAY_URL%' -OutFile '%GATEWAY_FILE%.download'; exit 0 } catch { exit 1 }"
+if errorlevel 1 exit /b 1
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$p='%GATEWAY_FILE%.download'; if ((Test-Path $p) -and ((Get-Item $p).Length -gt 100000) -and ([IO.File]::ReadAllBytes($p)[0] -eq 0x4D) -and ([IO.File]::ReadAllBytes($p)[1] -eq 0x5A)) { exit 0 }; exit 1"
+if errorlevel 1 (
+    del /q "%GATEWAY_FILE%.download" >nul 2>nul
+    exit /b 1
+)
+move /y "%GATEWAY_FILE%.download" "%GATEWAY_FILE%" >nul
+exit /b 0
+
+:download_wheel
+set "WHEEL_NAME=%~1"
+set "DIRECT_URL=%~2"
+set "WHEEL_PATH=%~3"
+set "DOWNLOAD_OK=0"
+
+for %%U in (
+    "!DIRECT_URL!"
+    "!MIRROR_1!!DIRECT_URL!"
+    "!MIRROR_2!!DIRECT_URL!"
+    "!MIRROR_3!!DIRECT_URL!"
+    "!MIRROR_4!!DIRECT_URL!"
+) do (
+    if "!DOWNLOAD_OK!"=="0" (
+        echo [INFO] Trying download source: %%~U
+        del /q "!WHEEL_PATH!.download" >nul 2>nul
+        powershell -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 45 -Uri '%%~U' -OutFile '!WHEEL_PATH!.download'; exit 0 } catch { exit 1 }"
+        if not errorlevel 1 (
+            powershell -NoProfile -ExecutionPolicy Bypass -Command "$p='!WHEEL_PATH!.download'; if ((Test-Path $p) -and ((Get-Item $p).Length -gt 1000)) { $b=[IO.File]::ReadAllBytes($p); if ($b[0] -eq 0x50 -and $b[1] -eq 0x4B) { exit 0 } }; exit 1"
+            if not errorlevel 1 (
+                move /y "!WHEEL_PATH!.download" "!WHEEL_PATH!" >nul
+                set "DOWNLOAD_OK=1"
+                echo [INFO] Download succeeded.
+            ) else (
+                del /q "!WHEEL_PATH!.download" >nul 2>nul
+                echo [WARN] Downloaded content was not a valid wheel. Trying next source...
+            )
+        ) else (
+            del /q "!WHEEL_PATH!.download" >nul 2>nul
+            echo [WARN] Download source failed. Trying next source...
+        )
+    )
+)
+
+if "!DOWNLOAD_OK!"=="1" exit /b 0
+exit /b 1
+
+:pause
+pause
+exit /b 0


### PR DESCRIPTION
## 背景
为降低新用户部署门槛，提供双击即可运行的启动脚本，并支持清理本地依赖的脚本。

## 变更
- 新增 start.bat：自动准备 uv，自动解析最新 Release，下载并校验 KouriChat/Elixir wheel，支持镜像回退。
- 启动前检查 openclaw-onebotv11.exe 网关文件；依赖或网关不完整时不启动 KouriChat。
- 顶部集中配置 Release API、wheel 下载源、镜像地址和可选网关地址。
- 新增 clean.bat：卸载 uv tool、删除 wheel 缓存和本地虚拟环境，默认确认并在 5 秒后关闭窗口。

## 验证
- git diff --cached --check
- BAT 编码检查：UTF-8 无 BOM，CRLF 行尾
- 已实际验证 wheel 下载和 uv 安装流程

## 给官方的提示
后续需要将相关核心文件对应直链填入start.bat后发行